### PR TITLE
* feat(docs): add item-1.md and item-2.md to the documentation

### DIFF
--- a/docs/item-1.md
+++ b/docs/item-1.md
@@ -1,0 +1,6 @@
+---
+sidebar_label: Item 1
+---
+
+# Item 1
+

--- a/docs/item-2.md
+++ b/docs/item-2.md
@@ -1,0 +1,9 @@
+---
+sidebar_label: Item 2
+---
+
+# Item 2
+
+## Heading 2
+### Sub-item 2
+

--- a/index.js
+++ b/index.js
@@ -1,8 +1,19 @@
 #!/usr/bin/env node
 
 const {generateSidebarsFile, buildSidebarsLayout, validateFilesAndShowDuplicatedLabels} = require('./lib/skelo-utils');
+const fs = require('fs');
+const path = require('path');
+const {Command} = require('commander');
 
-const { Command} = require('commander');
+const SKELO_CONFIG_FILE = './skelo.config.json';
+
+const DEFAULT_TEMPLATE_NAMES = {
+  "templateNames": {
+    "SIDEBARS_TEMPLATE": "sidebars",
+    "TOPIC_TEMPLATE": "topic",
+    "HEADING_TEMPLATE": "heading"
+  }
+}
 
 const fallbackPatterns = [
   '**/*.outline.yaml',
@@ -12,6 +23,26 @@ const fallbackPatterns = [
 ]
 
 const {version, name, description} = require('./package.json');
+
+/**
+ * Reads a configuration file and returns a merged configuration
+ * of defaultTemplateNames and the JSON content of the file.
+ * If the file does not exist or there is an error reading/parsing
+ * the content, it returns the defaultTemplateNames.
+ * @param {string} configFile - The path to the configuration file.
+ * @returns {Object} Merged configuration object.
+ */
+function getConfiguration(configFile) {
+  try {
+    if (fs.existsSync(configFile)) {
+      const configContent = fs.readFileSync(configFile, 'utf8');
+      return {...DEFAULT_TEMPLATE_NAMES, ...JSON.parse(configContent)};
+    }
+  } catch (err) {
+      console.error("Error reading or parsing config file:", err);
+      return DEFAULT_TEMPLATE_NAMES;
+    }
+  }
 
 let program = new Command();
 
@@ -24,7 +55,7 @@ program
     sortOptions: true,
     showGlobalOptions: true,
     width: 100
-    })
+  })
 
 program
   .command('build', {isDefault: true})
@@ -48,8 +79,11 @@ program
   })
 
   .action((patterns, options) => {
-    const generatedSidebarsLayout = buildSidebarsLayout(patterns, options);
-    generateSidebarsFile(generatedSidebarsLayout, options);
+    const configFile = path.resolve(SKELO_CONFIG_FILE);
+    const config = getConfiguration(configFile);
+    const combinedOptions = {...options, ...config} // Combine config with CLI options
+    const generatedSidebarsLayout = buildSidebarsLayout(patterns, combinedOptions);
+    generateSidebarsFile(generatedSidebarsLayout, combinedOptions);
   })
 
 program
@@ -61,7 +95,10 @@ program
   .option('--fallback-patterns <patterns...>', 'Fallback glob patterns for outline files', fallbackPatterns)
   .option('--schemaFilename <path>', 'Schema file', 'schemas/outline/v1/outline.schema.json')
   .action((patterns, options) => {
-    validateFilesAndShowDuplicatedLabels(patterns, options);
+    const configFile = path.resolve(SKELO_CONFIG_FILE);
+    const config = getConfiguration(configFile);
+    const combinedOptions = {...options, ...config}; // Combine config with CLI options
+    validateFilesAndShowDuplicatedLabels(patterns, combinedOptions);
   })
 
   .configureHelp({

--- a/lib/skelo-utils.js
+++ b/lib/skelo-utils.js
@@ -344,8 +344,10 @@ function saveTopic(item, topicBasename, options) {
 
 function buildTopicContent(item, options) {
     const { label, title } = item;
+    const {templateNames} = options;
+    const {TOPIC_TEMPLATE} = templateNames;
     return renderTemplate(
-        'topic', 
+        TOPIC_TEMPLATE, 
         { 
            ...item,
             headingItems: buildHeadingItems(item.headings || [], 2, options).trim(),
@@ -355,8 +357,10 @@ function buildTopicContent(item, options) {
 }
 
 function buildHeadingItems(items, level = 2, options) {
+    const { templateNames } = options;
+    const { HEADING_TEMPLATE } = templateNames;
     return items.map(item => {
-        return renderTemplate('heading', { label: item.label, prefix: '#'.repeat(level), headingItems: buildHeadingItems(item.items || [], level + 1, options).trim() }, options);
+        return renderTemplate(HEADING_TEMPLATE, { label: item.label, prefix: '#'.repeat(level), headingItems: buildHeadingItems(item.items || [], level + 1, options).trim() }, options);
     }).join('\n')
 }
 
@@ -586,7 +590,9 @@ function generateSidebarsFile(sidebarsData, options) {
     }
 
     // Render the sidebars template
-    const outputContent = renderTemplate('sidebars', { sidebars: JSON.stringify(sidebarsData, null, 2) }, options);
+    const { templateNames } = options;
+    const { SIDEBARS_TEMPLATE } = templateNames;
+    const outputContent = renderTemplate(SIDEBARS_TEMPLATE, { sidebars: JSON.stringify(sidebarsData, null, 2) }, options);
 
     // Determine the output filename
     const outputFilename = setExtensionIfMissing(sidebarsFilename, '.js');

--- a/sidebars.js
+++ b/sidebars.js
@@ -1,0 +1,8 @@
+const sidebars = {
+  "Unique Sidebar with items": [
+    "item-1",
+    "item-2"
+  ]
+};
+
+module.exports = sidebars;

--- a/skelo.config.json
+++ b/skelo.config.json
@@ -1,0 +1,7 @@
+{
+    "templateNames": {
+        "SIDEBARS_TEMPLATE": "sidebars",
+        "TOPIC_TEMPLATE": "topic",
+        "HEADING_TEMPLATE": "heading"
+    }
+}

--- a/test/website/docs/item-1.md
+++ b/test/website/docs/item-1.md
@@ -1,0 +1,6 @@
+---
+sidebar_label: Item 1
+---
+
+# Item 1
+

--- a/test/website/docs/item-2.md
+++ b/test/website/docs/item-2.md
@@ -1,0 +1,9 @@
+---
+sidebar_label: Item 2
+---
+
+# Item 2
+
+## Heading 2
+### Sub-item 2
+


### PR DESCRIPTION
* feat(index.js): add support for configuration file and merge with CLI options
* fix(skelo-utils.js): use template names from options in buildTopicContent and buildHeadingItems functions
* feat(skelo-utils.js): use template names from options in generateSidebarsFile function
* feat(skelo.config.json): add configuration file with template names
* feat(test/website/docs): add item-1.md and item-2.md to the test website documentation